### PR TITLE
Only select pages starting from next root page in rootline

### DIFF
--- a/class.tx_seobasics_sitemap.php
+++ b/class.tx_seobasics_sitemap.php
@@ -134,6 +134,17 @@ class tx_seobasics_sitemap {
 			// disable recycler and everything below
 		$tree->init('AND doktype!=255' . $GLOBALS['TSFE']->sys_page->enableFields('pages'));
 
+		// Only select pages starting from next root page in rootline
+		$rootline = $GLOBALS['TSFE']->rootLine;
+	        if (count($rootline) > 0) {
+	            $i = count($rootline) - 1;
+	            $page = $rootline[$i];
+	            while (!(boolean)$page['is_siteroot'] && $i >= 0) {
+	                $i--;
+	                $page = $rootline[$i];
+	
+	            }
+	        }
 
 			// create the tree from starting point
 		$tree->getTree($id, $depth, '');


### PR DESCRIPTION
In a multi-domain and multi-root-environment of a TYPO3 system the XML sitemap lists links of all domains in the tree. This patch solves the problem by searching for the next root page and only listing links starting from this point.
