### PR TITLE
[TASK] Remove maximum field length of input fields

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,7 +9,6 @@ $additionalColumns = array(
 		'config' => array(
 			'type' => 'input',
 			'size' => 70,
-			'max'  => 70,
 			'eval' => 'trim'
 		)
 	),
@@ -19,7 +18,6 @@ $additionalColumns = array(
 		'config'  => array(
 			'type' => 'input',
 			'size' => 70,
-			'max'  => 70,
 			'eval' => 'trim'
 		)
 	)

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -9,7 +9,6 @@ $additionalColumns = array(
 		'config' => array(
 			'type' => 'input',
 			'size' => 70,
-			'max'  => 70,
 			'eval' => 'trim'
 		)
 	),
@@ -19,7 +18,6 @@ $additionalColumns = array(
 		'config'  => array(
 			'type' => 'input',
 			'size' => 70,
-			'max'  => 70,
 			'eval' => 'trim'
 		)
 	)


### PR DESCRIPTION
Google may only display about 60 characters for the page title but nobody knows exactly how many characters are relevant in a search result.