### PR TITLE
Don't select column cache_id  from table tx_realurl_pathcache

### DIFF
--- a/Classes/BackendModule/SeoModule.php
+++ b/Classes/BackendModule/SeoModule.php
@@ -421,7 +421,7 @@ class SeoModule extends \TYPO3\CMS\Backend\Module\AbstractFunctionModule {
 		$where = ($this->langOnly || $this->langOnly === 0 ? ' AND language_id = ' . $this->langOnly : '');
 
 		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'page_id, language_id, pagepath, cache_id ',
+			'page_id, language_id, pagepath',
 			'tx_realurl_pathcache',
 			'page_id IN ('. $uidList .') ' . $where,
 			'',


### PR DESCRIPTION
It is not used anywhere and has been superceded by uid in Real URL 2.0.

Solves #32.