### PR TITLE
[FEATURE] add robots meta tag as page property option

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -20,7 +20,23 @@ $additionalColumns = array(
 			'size' => 70,
 			'eval' => 'trim'
 		)
-	)
-);
+	),
+    'tx_seo_robots' => array(
+        'exclude' => 1,
+        'label'   => 'LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots',
+        'config' => array(
+            'type' => 'select',
+            'minitems' => 1,
+            'maxitems' => 1,
+            'size' => 1,
+            'items' => array(
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.0', '0'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.1', '1'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.2', '2'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.3', '3'),
+            ),
+        )
+    ),
+ );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_seo_titletag, tx_seo_canonicaltag', 1, 'before:keywords');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_seo_titletag, tx_seo_canonicaltag, tx_seo_robots', 1, 'before:keywords');

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -20,10 +20,26 @@ $additionalColumns = array(
 			'size' => 70,
 			'eval' => 'trim'
 		)
-	)
+	),
+    'tx_seo_robots' => array(
+        'exclude' => 1,
+        'label'   => 'LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots',
+        'config' => array(
+            'type' => 'select',
+            'minitems' => 1,
+            'maxitems' => 1,
+            'size' => 1,
+            'items' => array(
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.0', '0'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.1', '1'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.2', '2'),
+                array('LLL:EXT:seo_basics/Resources/Private/Language/db.xml:pages.tx_seo_robots.I.3', '3'),
+            ),
+        )
+    ),
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', $additionalColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages_language_overlay', 'tx_seo_titletag, tx_seo_canonicaltag', '1', 'before:keywords');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages_language_overlay', 'tx_seo_titletag, tx_seo_canonicaltag, tx_seo_robots', '1', 'before:keywords');
 
-$GLOBALS['TCA']['pages_language_overlay']['interface']['showRecordFieldList'] .= ',tx_seo_titletag, tx_seo_canonicaltag';
+$GLOBALS['TCA']['pages_language_overlay']['interface']['showRecordFieldList'] .= ',tx_seo_titletag, tx_seo_canonicaltag, tx_seo_robots';

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -66,6 +66,18 @@ plugin.tx_seobasics {
 	60.if.isTrue = {$plugin.tx_seo.enableCanonicalTag}
 	60.stdWrap >
 	60.wrap = <link rel="canonical" href="|" />
+
+	# add robots tag
+	70 = CASE
+	70.key.field = tx_seo_robots
+	70.1 = TEXT
+	70.1.value = noindex
+	70.2 = TEXT
+	70.2.value = noindex,follow
+	70.3 = TEXT
+	70.3.value = index,nofollow
+	70.stdWrap.wrap = <meta name="robots" content=" | " />
+	70.stdWrap.append < .5
 }
 
 

--- a/Resources/Private/Language/db.xml
+++ b/Resources/Private/Language/db.xml
@@ -8,11 +8,21 @@
 		<languageKey index="default" type="array">
 			<label index="pages.titletag">&lt;title&gt; Tag:</label>
 			<label index="pages.canonicaltag">Canonical URL:</label>
+			<label index="pages.noindex">Add &quot;noindex&quot; tag</label>
+			<label index="pages.nofollow">Add &quot;nofollow&quot; tag</label>
+			<label index="pages.follow">Add &quot;follow&quot; tag (for noindex,follow)</label>
+			<label index="pages.tx_seo_robots">Additional meta &quot;robots&quot; tags for this page</label>
+			<label index="pages.tx_seo_robots.I.0">no additional configuration</label>
+			<label index="pages.tx_seo_robots.I.1">noindex</label>
+			<label index="pages.tx_seo_robots.I.2">noindex,follow</label>
+			<label index="pages.tx_seo_robots.I.3">index,nofollow</label>
 			<label index="module.title">SEO Management</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="pages.titletag">Title Tag:</label>
 			<label index="pages.canonicaltag">Canonical URL:</label>
+			<label index="pages.tx_seo_robots">Zusätzliche &quot;robots&quot;-Metatags für diese Seite</label>
+			<label index="pages.tx_seo_robots.I.0">keine zusätzliche Konfiguration</label>
 			<label index="module.title">SEO Management</label>
 		</languageKey>
 	</data>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,7 +2,7 @@
 defined('TYPO3_MODE') or die();
 
 // adding th tx_seo_titletag to the pageOverlayFields so it is recognized when fetching the overlay fields
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_seo_titletag,tx_seo_canonicaltag';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_seo_titletag,tx_seo_canonicaltag,tx_seo_robots';
 
 $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['seo_basics']);
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,7 +3,8 @@
 #
 CREATE TABLE pages (
 	tx_seo_titletag tinytext,
-	tx_seo_canonicaltag tinytext
+	tx_seo_canonicaltag tinytext,
+	tx_seo_robots tinytext
 );
 
 #
@@ -11,5 +12,6 @@ CREATE TABLE pages (
 #
 CREATE TABLE pages_language_overlay (
 	tx_seo_titletag tinytext,
-	tx_seo_canonicaltag tinytext
+	tx_seo_canonicaltag tinytext,
+	tx_seo_robots tinytext
 );


### PR DESCRIPTION
This change adds a dropdown element to the page properties for optional settings of the "robots" meta tag to allow single pages to be excluded from listing in the index of Google and others. 

This proposed feature is sponsored by Hoffnungsträger Stiftung, hoffnungstraeger.de.