### PR TITLE
[BUGFIX] Avoid PHP warning in backend module

### DIFF
--- a/Classes/BackendModule/SeoModule.php
+++ b/Classes/BackendModule/SeoModule.php
@@ -67,7 +67,7 @@ class SeoModule extends \TYPO3\CMS\Backend\Module\AbstractFunctionModule {
 	 *
 	 * @return	array
 	 */
-	public function init($pObj, $conf) {
+	public function init(&$pObj, $conf) {
 		// load languages
 		$trans = GeneralUtility::makeInstance('TYPO3\\CMS\\Backend\\Configuration\\TranslationConfigurationProvider');
 		$this->sysLanguages = $trans->getSystemLanguages($pObj->id, $GLOBALS['BACK_PATH']);


### PR DESCRIPTION
PHP requires that the declaration of the backend module
should be compatible with the abstract module.

To fulfill this requirement and avoid the exception
warning the declaration is changed.
