### PR TITLE
Updated the list of RealURL hooks in ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,7 +9,7 @@ $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extCon
 	// registering sitemap.xml for each hierachy of configuration to realurl (meaning to every website in a multisite installation)
 if ($extensionConfiguration['xmlSitemap'] == '1') {
 	$realurl = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl'];
-	$hooks = array('encodeSpURL_postProc', 'decodeSpURL_preProc', 'getHost');
+    $hooks = array('encodeSpURL_earlyHook', 'encodeSpURL_postProc', 'decodeSpURL_preProc', 'getHost', 'ConfigurationReader_postProc', 'storeInUrlCache');
 	if (is_array($realurl))	{
 		foreach ($realurl as $host => $cnf) {
 			// we won't do anything with string pointer (e.g. example.org => www.example.org)


### PR DESCRIPTION
Updated the list of RealURL hooks with all the existing hooks in the latest version of the extension (2.3.2). Before this update RealURL could not be extended by the new hooks introduced in the latest versions if seo_basics is installed with sitemap.xml feature activated.