### PR TITLE
bugfix for compatibility with realurl 2

### DIFF
--- a/Classes/BackendModule/SeoModule.php
+++ b/Classes/BackendModule/SeoModule.php
@@ -33,6 +33,7 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 /**
  * SEO Management module
@@ -476,7 +477,7 @@ class SeoModule extends \TYPO3\CMS\Backend\Module\AbstractFunctionModule
 
         $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'page_id, language_id, pagepath',
-            'tx_realurl_pathcache',
+            version_compare(ExtensionManagementUtility::getExtensionVersion('realurl'), '2.0', '<') ? 'tx_realurl_pathcache' : 'tx_realurl_pathdata',
             'page_id IN (' . $uidList . ') ' . $where,
             '',
             'language_id ASC, expire ASC'


### PR DESCRIPTION
reason: table “tx_realurl_pathcache” was renamed to “tx_realurl_pathdata” since version 2 of realurl